### PR TITLE
Add clinical trials app link

### DIFF
--- a/_pages/related.md
+++ b/_pages/related.md
@@ -19,6 +19,7 @@ This website contains visualizations and analysis that are build from data sourc
 - Boston's Children's Hospital [Health Map project](https://healthmap.org/covid-19/).  Includes this [GitHub repo](https://github.com/beoutbreakprepared/nCoV2019) and this [Google sheet](https://docs.google.com/spreadsheets/d/1itaohdPiAeniCXNlntNztZ_oRvjh0HsGuJXUJWET008/edit#gid=0)
 - [https://ncov2019.live](https://ncov2019.live/data): This is really a dashboard, but presents most of its data in a tabular format that can be scraped.
 - Official Italian government [GitHub repo](https://github.com/pcm-dpc/COVID-19). Updated regularly by the Italian Ministry of Health and Dipartimento di Protezione Civile. Contains multiple indicators such as number of total cases, number in ICU, number of tests done, etc.
+- [https://kishorevasan.shinyapps.io/coronavirus_clinical_trials/](https://kishorevasan.shinyapps.io/coronavirus_clinical_trials/) : An interactive dashboard that tracks clinical trials related to Novel Coronavirus. Uses clinicaltrials.gov data and is updated using API calls. 
 
 ## Articles
 


### PR DESCRIPTION
Updated the data sources to include a link to the clinical trials shiny app.